### PR TITLE
Attempt to limit only one process fetching in case of cache miss

### DIFF
--- a/include/leo_cache.hrl
+++ b/include/leo_cache.hrl
@@ -101,7 +101,8 @@
                        disc_cache_mod      :: atom(),
                        disc_cache_active   :: boolean(),
                        cache_workers       :: pos_integer(),
-                       chunk_threshold_len :: pos_integer()
+                       chunk_threshold_len :: pos_integer(),
+                       cache_holder        :: pid()
                       }).
 
 -record(stats,  {get     = 0 :: non_neg_integer(),

--- a/src/leo_cache_api.erl
+++ b/src/leo_cache_api.erl
@@ -220,7 +220,7 @@ release(Key)->
             Holder = Item#cache_server.cache_holder,
             leo_cache_holder:release(Holder, Key);
         _ ->
-            void
+            ok
     end.
 
 %% @doc Hold the cache to prevent duplicate retrival
@@ -230,9 +230,14 @@ hold(Key)->
     case ets:lookup(?ETS_CACHE_SERVER_INFO, 0) of
         [{_, Item}|_] ->
             Holder = Item#cache_server.cache_holder,
-            leo_cache_holder:hold(Holder, Key);
+            case leo_cache_holder:hold(Holder, Key) of
+                {error, _} ->
+                    leo_cache_holder:wait(Holder, Key);
+                {ok, _} ->
+                    ok
+            end;
         _ ->
-            void
+            ok
     end.
 
 %% @doc Hold the cache to prevent duplicate retrival
@@ -243,9 +248,14 @@ hold(Key, HoldTime)->
     case ets:lookup(?ETS_CACHE_SERVER_INFO, 0) of
         [{_, Item}|_] ->
             Holder = Item#cache_server.cache_holder,
-            leo_cache_holder:hold(Holder, Key, HoldTime);
+            case leo_cache_holder:hold(Holder, Key, HoldTime) of
+                {error, _} ->
+                    leo_cache_holder:wait(Holder, Key);
+                {ok, _} ->
+                    ok
+            end;
         _ ->
-            void
+            ok
     end.
 
 %% @doc Retrieve an object from the momory storage

--- a/src/leo_cache_api.erl
+++ b/src/leo_cache_api.erl
@@ -33,7 +33,8 @@
 -include_lib("eunit/include/eunit.hrl").
 
 %% External API
--export([start/0, start/1, stop/0, hold/1,
+-export([start/0, start/1, stop/0, 
+         hold/1, hold/2, release/1, 
          get_filepath/1, get_ref/1, get/1, get/2,
          put/2, put/3, put_begin_tran/1, put_end_tran/4,
          delete/1, stats/0]).
@@ -210,6 +211,18 @@ get_filepath(Key) ->
             not_found
     end.
 
+%% @doc Release the holder
+-spec(release(Key) ->
+    {ok, pid()} | {error, any()} when Key::binary()).
+release(Key)->
+    case ets:lookup(?ETS_CACHE_SERVER_INFO, 0) of
+        [{_, Item}|_] ->
+            Holder = Item#cache_server.cache_holder,
+            leo_cache_holder:release(Holder, Key);
+        _ ->
+            void
+    end.
+
 %% @doc Hold the cache to prevent duplicate retrival
 -spec(hold(Key) -> 
     {ok, pid()} | {error, any()} when Key::binary()).
@@ -218,6 +231,19 @@ hold(Key)->
         [{_, Item}|_] ->
             Holder = Item#cache_server.cache_holder,
             leo_cache_holder:hold(Holder, Key);
+        _ ->
+            void
+    end.
+
+%% @doc Hold the cache to prevent duplicate retrival
+-spec(hold(Key, HoldTime) -> 
+    {ok, pid()} | {error, any()} when Key::binary(),
+                                      HoldTime::integer()).
+hold(Key, HoldTime)->
+    case ets:lookup(?ETS_CACHE_SERVER_INFO, 0) of
+        [{_, Item}|_] ->
+            Holder = Item#cache_server.cache_holder,
+            leo_cache_holder:hold(Holder, Key, HoldTime);
         _ ->
             void
     end.

--- a/src/leo_cache_api.erl
+++ b/src/leo_cache_api.erl
@@ -33,7 +33,7 @@
 -include_lib("eunit/include/eunit.hrl").
 
 %% External API
--export([start/0, start/1, stop/0,
+-export([start/0, start/1, stop/0, hold/1,
          get_filepath/1, get_ref/1, get/1, get/2,
          put/2, put/3, put_begin_tran/1, put_end_tran/4,
          delete/1, stats/0]).
@@ -70,6 +70,8 @@ start(Options) ->
                            ],
     ok = leo_misc:set_env(leo_cache, ?PROP_OPTIONS, Options_1),
 
+    {ok, Holder} = leo_cache_holder:start(),
+
     %% Create the cache-related tables to manage the cache servers
     case catch start_1() of
         {'EXIT', Cause} ->
@@ -77,14 +79,14 @@ start(Options) ->
         ok ->
             %% Launch the memory-cache server
             CacheWorkers =
-                case IsActiveRAMCache of
-                    true ->
-                        Workers1 = leo_misc:get_value(?PROP_RAM_CACHE_WORKERS, Options_1),
-                        ok = RC:start(Workers1, Options_1),
-                        Workers1;
-                    false ->
-                        0
-                end,
+            case IsActiveRAMCache of
+                true ->
+                    Workers1 = leo_misc:get_value(?PROP_RAM_CACHE_WORKERS, Options_1),
+                    ok = RC:start(Workers1, Options_1),
+                    Workers1;
+                false ->
+                    0
+            end,
 
             %% Launch the disk-cache server
             case IsActiveDiscCache of
@@ -102,7 +104,8 @@ start(Options) ->
                                                 disc_cache_mod      = DC,
                                                 disc_cache_active   = IsActiveDiscCache,
                                                 cache_workers       = CacheWorkers,
-                                                chunk_threshold_len = ChunkThresholdLen
+                                                chunk_threshold_len = ChunkThresholdLen,
+                                                cache_holder        = Holder
                                                }}),
             ok
     end.
@@ -161,6 +164,14 @@ stop() ->
         undifined -> void;
         DC -> DC:stop()
     end,
+
+    case ets:lookup(?ETS_CACHE_SERVER_INFO, 0) of
+        [{_, Item}|_] ->
+            Holder = Item#cache_server.cache_holder,
+            leo_cache_holder:stop(Holder);
+        _ ->
+            void
+    end,
     ok.
 
 
@@ -189,7 +200,9 @@ get_ref(Key) ->
 get_filepath(Key) ->
     #cache_server{disc_cache_mod    = DC,
                   disc_cache_index  = Id,
-                  disc_cache_active = Active} = ?cache_servers(Key),
+                  disc_cache_active = Active,
+                  cache_holder      = Holder} = ?cache_servers(Key),
+    leo_cache_holder:wait(Holder, Key),
     case Active of
         true ->
             DC:get_filepath(Id, Key);
@@ -197,6 +210,17 @@ get_filepath(Key) ->
             not_found
     end.
 
+%% @doc Hold the cache to prevent duplicate retrival
+-spec(hold(Key) -> 
+    {ok, pid()} | {error, any()} when Key::binary()).
+hold(Key)->
+    case ets:lookup(?ETS_CACHE_SERVER_INFO, 0) of
+        [{_, Item}|_] ->
+            Holder = Item#cache_server.cache_holder,
+            leo_cache_holder:hold(Holder, Key);
+        _ ->
+            void
+    end.
 
 %% @doc Retrieve an object from the momory storage
 -spec(get(Key) ->
@@ -209,8 +233,10 @@ get(Key) ->
                   ram_cache_active  = Active1,
                   disc_cache_mod    = DC,
                   disc_cache_index  = Id2,
-                  disc_cache_active = Active2} = ?cache_servers(Key),
+                  disc_cache_active = Active2, 
+                  cache_holder      = Holder} = ?cache_servers(Key),
 
+    leo_cache_holder:wait(Holder, Key),
     case Active1 of
         true ->
             case RC:get(Id1, Key) of
@@ -238,7 +264,9 @@ get(Key) ->
 get(Ref, Key) ->
     #cache_server{disc_cache_mod    = DC,
                   disc_cache_index  = Id,
-                  disc_cache_active = Active} = ?cache_servers(Key),
+                  disc_cache_active = Active,
+                  cache_holder      = Holder} = ?cache_servers(Key),
+    leo_cache_holder:wait(Holder, Key),
     case Active of
         true ->
             DC:get(Id, Ref, Key);
@@ -258,19 +286,22 @@ put(Key, Value) ->
                   disc_cache_mod    = DC,
                   disc_cache_index  = Id2,
                   disc_cache_active = Active2,
-                  chunk_threshold_len = ChunkThresholdLen} = ?cache_servers(Key),
+                  chunk_threshold_len = ChunkThresholdLen,
+                  cache_holder      = Holder} = ?cache_servers(Key),
 
-    case (size(Value) < ChunkThresholdLen) of
-        true when Active1 == true ->
-            RC:put(Id1, Key, Value);
-        true ->
-            ok;
-        false when Active2 == true ->
-            DC:put(Id2, Key, Value);
-        false ->
-            ok
-    end.
+    Ret = case (size(Value) < ChunkThresholdLen) of
+              true when Active1 == true ->
+                  RC:put(Id1, Key, Value);
+              true ->
+                  ok;
+              false when Active2 == true ->
+                  DC:put(Id2, Key, Value);
+              false ->
+                  ok
+          end,
 
+    leo_cache_holder:release(Holder, Key),
+    Ret.
 
 %% @doc Insert a chunked-object into the disc
 -spec(put(Ref, Key, Value) ->
@@ -313,13 +344,17 @@ put_begin_tran(Key) ->
 put_end_tran(Ref, Key, Meta, IsCommit) ->
     #cache_server{disc_cache_mod    = DC,
                   disc_cache_index  = Id,
-                  disc_cache_active = Active} = ?cache_servers(Key),
-    case Active of
-        true ->
-            DC:put_end_tran(Id, Ref, Key, Meta, IsCommit);
-        false ->
-            {error, ?ERROR_INVALID_OPERATION}
-    end.
+                  disc_cache_active = Active,
+                  cache_holder = Holder} = ?cache_servers(Key),
+    Ret = case Active of
+              true ->
+                  DC:put_end_tran(Id, Ref, Key, Meta, IsCommit);
+              false ->
+                  {error, ?ERROR_INVALID_OPERATION}
+          end,
+
+    leo_cache_holder:release(Holder, Key),
+    Ret.
 
 
 %% @doc Remove an object from the momory storage

--- a/src/leo_cache_holder.erl
+++ b/src/leo_cache_holder.erl
@@ -42,6 +42,8 @@ wait(Pid, Key, WaitTime) ->
         {ok, Holder} when is_pid(Pid) ->
             monitor(process, Holder),
             receive
+                _Any ->
+                    ok
             after
                 WaitTime -> ok
             end;

--- a/src/leo_cache_holder.erl
+++ b/src/leo_cache_holder.erl
@@ -51,6 +51,9 @@ handle_call(stop, _From, State) ->
 handle_call({hold, Key, HoldTime}, _From, State=#state{db = DB})->
     Pid = spawn_link(fun() ->
                         receive
+                            _Any ->
+                                ets:delete(DB, Key),
+                                ok
                         after
                             HoldTime -> 
                                 ets:delete(DB, Key),

--- a/src/leo_cache_holder.erl
+++ b/src/leo_cache_holder.erl
@@ -1,0 +1,83 @@
+-module(leo_cache_holder).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-export([start/0, stop/1, init/1]).
+-export([hold/2, release/2, wait/2]).
+-export([hold/3, wait/3]).
+-export([handle_call/3]).
+-export([terminate/2]).
+
+-record(state, {db :: ets:tid()}).
+
+-define(DEF_HOLD_TIME, 5000).
+-define(DEF_WAIT_TIME, 1000).
+
+start() ->
+    gen_server:start_link(?MODULE, [], []).
+
+stop(Pid) ->
+    gen_server:call(Pid, stop),
+    ok.
+
+init(_Options) ->
+    DB = ets:new(?MODULE, [named_table, set, public]),
+    {ok, #state{db = DB}}.
+
+hold(Pid, Key) ->
+    hold(Pid, Key, ?DEF_HOLD_TIME).
+hold(Pid, Key, HoldTime) ->
+    gen_server:call(Pid, {hold, Key, HoldTime}).
+
+release(Pid, Key) ->
+    gen_server:call(Pid, {release, Key}).
+
+wait(Pid, Key) ->
+    wait(Pid, Key, ?DEF_WAIT_TIME).
+wait(Pid, Key, WaitTime) ->
+    case gen_server:call(Pid, {lookup, Key}) of
+        {ok, Holder} when is_pid(Pid)->
+            monitor(process, Holder),
+            receive
+            after
+                WaitTime -> ok
+            end;
+        {_, _} ->
+            ok
+    end.
+
+handle_call(stop, _From, State) ->
+    {stop, normal, ok, State};
+handle_call({hold, Key, HoldTime}, _From, State=#state{db = DB})->
+    Pid = spawn_link(fun() ->
+                        receive
+                        after
+                            HoldTime -> 
+                                ets:delete(DB, Key),
+                                ok
+                        end 
+                end),
+    case ets:insert_new(DB, {Key, Pid}) of
+        true ->
+            {reply, {ok, Pid}, State};
+        false->
+            {reply, {error, exist}, State}
+    end;
+handle_call({lookup, Key}, _From, State=#state{db = DB}) ->
+    case ets:lookup(DB, Key) of
+        [{Key, Pid}] ->
+            {reply, {ok, Pid}, State};
+        _ ->
+            {reply, {error, not_found}, State}
+    end;
+handle_call({release, Key}, _From, State=#state{db = DB}) ->
+    case ets:lookup(DB, Key) of
+        [{Key, Pid}] ->
+            Pid ! {ok},
+            {reply, {ok, Pid}, State};
+        _ ->
+            {reply, {error, not_found}, State}
+    end.
+
+terminate(normal, _State) ->
+    ok.

--- a/src/leo_cache_holder.erl
+++ b/src/leo_cache_holder.erl
@@ -2,11 +2,14 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
+-behavior(gen_server).
+
 -export([start/0, stop/1, init/1]).
 -export([hold/2, release/2, wait/2]).
 -export([hold/3, wait/3]).
 -export([handle_call/3]).
 -export([terminate/2]).
+-export([handle_cast/2, handle_info/2, code_change/3]).
 
 -record(state, {db :: ets:tid()}).
 
@@ -49,7 +52,7 @@ wait(Pid, Key, WaitTime) ->
 handle_call(stop, _From, State) ->
     {stop, normal, ok, State};
 handle_call({hold, Key, HoldTime}, _From, State=#state{db = DB})->
-    Pid = spawn_link(fun() ->
+    Pid = spawn(fun() ->
                         receive
                             _Any ->
                                 ets:delete(DB, Key),
@@ -84,3 +87,13 @@ handle_call({release, Key}, _From, State=#state{db = DB}) ->
 
 terminate(normal, _State) ->
     ok.
+
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+%% @doc Convert process state when code is changed
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.

--- a/src/leo_cache_holder.erl
+++ b/src/leo_cache_holder.erl
@@ -55,7 +55,6 @@ handle_call({hold, Key, HoldTime}, _From, State=#state{db = DB})->
     Pid = spawn(fun() ->
                         receive
                             _Any ->
-                                ets:delete(DB, Key),
                                 ok
                         after
                             HoldTime -> 
@@ -86,6 +85,7 @@ handle_call({release, Key}, _From, State=#state{db = DB}) ->
     case ets:lookup(DB, Key) of
         [{Key, Pid}] ->
             Pid ! {ok},
+            ets:delete(DB, Key),
             {reply, {ok, Pid}, State};
         _ ->
             {reply, {error, not_found}, State}


### PR DESCRIPTION
## Attempt to fix issue leo-project/leofs#325

Added a module `leo_cache_holder`, process declares to hold an entry if it is going to fill the cache.
Other process tries to get or query the entry would be blocked to wait for its completion
## Usage code

windkit/leo_gateway@1dc1b47c5
