### PR TITLE
Avoid duplicate fetching upon cache miss by cache "lock"

### DIFF
--- a/include/leo_cache.hrl
+++ b/include/leo_cache.hrl
@@ -71,6 +71,8 @@
                       {?PROP_DISC_CACHE_DATA_DIR,      ?DEF_PROP_DISC_CACHE_DATA_DIR},
                       {?PROP_DISC_CACHE_JOURNAL_DIR,   ?DEF_PROP_DISC_CACHE_JOURNAL_DIR}
                      ]).
+-define(TRAN_TIMEOUT,   1000).
+-define(TRAN_WAITTIME,  1000).
 -else.
 -define(DEF_OPTIONS, [
                       {?PROP_RAM_CACHE_NAME,     ?DEF_PROP_RAM_CACHE},
@@ -84,6 +86,8 @@
                       {?PROP_DISC_CACHE_DATA_DIR,      ?DEF_PROP_DISC_CACHE_DATA_DIR},
                       {?PROP_DISC_CACHE_JOURNAL_DIR,   ?DEF_PROP_DISC_CACHE_JOURNAL_DIR}
                      ]).
+-define(TRAN_TIMEOUT,   1000).
+-define(TRAN_WAITTIME, 10000).
 -endif.
 
 

--- a/rebar.config
+++ b/rebar.config
@@ -29,7 +29,8 @@
 {deps, [
         {leo_commons, ".*", {git, "https://github.com/leo-project/leo_commons.git", {tag, "1.1.1"}}},
         {leo_mcerl,   ".*", {git, "https://github.com/leo-project/leo_mcerl.git",   {branch, "develop"}}},
-        {leo_dcerl,   ".*", {git, "https://github.com/leo-project/leo_dcerl.git",   {branch, "develop"}}}
+%        {leo_dcerl,   ".*", {git, "https://github.com/leo-project/leo_dcerl.git",   {branch, "develop"}}}
+        {leo_dcerl,   ".*", {git, "https://github.com/windkit/leo_dcerl.git",       {branch, "cache_tran"}}}
        ]}.
 
 {erl_opts, [{d, 'NOTEST'},

--- a/rebar.config
+++ b/rebar.config
@@ -28,8 +28,8 @@
 
 {deps, [
         {leo_commons, ".*", {git, "https://github.com/leo-project/leo_commons.git", {tag, "1.1.1"}}},
-        {leo_mcerl,   ".*", {git, "https://github.com/leo-project/leo_mcerl.git",   {tag, "0.4.1"}}},
-        {leo_dcerl,   ".*", {git, "https://github.com/leo-project/leo_dcerl.git",   {tag, "0.2.12"}}}
+        {leo_mcerl,   ".*", {git, "https://github.com/leo-project/leo_mcerl.git",   {branch, "develop"}}},
+        {leo_dcerl,   ".*", {git, "https://github.com/leo-project/leo_dcerl.git",   {branch, "develop"}}}
        ]}.
 
 {erl_opts, [{d, 'NOTEST'},

--- a/src/leo_cache_api.erl
+++ b/src/leo_cache_api.erl
@@ -148,7 +148,7 @@ get_filepath(Key) ->
                   disc_cache_active = Active} = ?cache_servers(Key),
     case Active of
         true ->
-            leo_cache_tran:has_tran(object, Key),
+%            leo_cache_tran:has_tran(object, Key),
             DC:get_filepath(Id, Key);
         false ->
             not_found
@@ -170,7 +170,7 @@ get(Key) ->
 
     case Active1 of
         true ->
-            leo_cache_tran:has_tran(object, Key),
+%            leo_cache_tran:has_tran(object, Key),
             case RC:get(Id1, Key) of
                 {ok, Bin} ->
                     {ok, Bin};
@@ -228,7 +228,7 @@ put(Key, Value) ->
               false ->
                   ok
           end,
-    leo_cache_tran:done_tran(object, Key),
+%    leo_cache_tran:done_tran(object, Key),
     Ret.
 
 
@@ -280,7 +280,7 @@ put_end_tran(Ref, Key, Meta, IsCommit) ->
               false ->
                   {error, ?ERROR_INVALID_OPERATION}
           end,
-    leo_cache_tran:done_tran(object, Key),
+%    leo_cache_tran:done_tran(object, Key),
     Ret.
 
 

--- a/src/leo_cache_api.erl
+++ b/src/leo_cache_api.erl
@@ -70,6 +70,8 @@ start(Options) ->
                            ],
     ok = leo_misc:set_env(leo_cache, ?PROP_OPTIONS, Options_1),
 
+    {ok, _} = leo_cache_tran:start_link(),
+
     %% Create the cache-related tables to manage the cache servers
     case catch start_1() of
         {'EXIT', Cause} ->
@@ -152,6 +154,7 @@ start_1() ->
 -spec(stop() ->
              ok).
 stop() ->
+    leo_cache_tran:stop(),
     Options = ?get_options(),
     case leo_misc:get_value(?PROP_RAM_CACHE_MOD,  Options) of
         undefined -> void;

--- a/src/leo_cache_api.erl
+++ b/src/leo_cache_api.erl
@@ -192,6 +192,7 @@ get_filepath(Key) ->
                   disc_cache_active = Active} = ?cache_servers(Key),
     case Active of
         true ->
+            leo_cache_tran:has_tran(object, Key),
             DC:get_filepath(Id, Key);
         false ->
             not_found
@@ -213,6 +214,7 @@ get(Key) ->
 
     case Active1 of
         true ->
+            leo_cache_tran:has_tran(object, Key),
             case RC:get(Id1, Key) of
                 {ok, Bin} ->
                     {ok, Bin};

--- a/src/leo_cache_api.erl
+++ b/src/leo_cache_api.erl
@@ -148,7 +148,7 @@ get_filepath(Key) ->
                   disc_cache_active = Active} = ?cache_servers(Key),
     case Active of
         true ->
-%            leo_cache_tran:has_tran(object, Key),
+%            leo_cache_tran:wait_tran(object, Key),
             DC:get_filepath(Id, Key);
         false ->
             not_found
@@ -170,7 +170,7 @@ get(Key) ->
 
     case Active1 of
         true ->
-%            leo_cache_tran:has_tran(object, Key),
+%            leo_cache_tran:wait_tran(object, Key),
             case RC:get(Id1, Key) of
                 {ok, Bin} ->
                     {ok, Bin};
@@ -228,7 +228,7 @@ put(Key, Value) ->
               false ->
                   ok
           end,
-%    leo_cache_tran:done_tran(object, Key),
+%    leo_cache_tran:end_tran(object, Key),
     Ret.
 
 
@@ -280,7 +280,7 @@ put_end_tran(Ref, Key, Meta, IsCommit) ->
               false ->
                   {error, ?ERROR_INVALID_OPERATION}
           end,
-%    leo_cache_tran:done_tran(object, Key),
+%    leo_cache_tran:end_tran(object, Key),
     Ret.
 
 

--- a/src/leo_cache_server_dcerl.erl
+++ b/src/leo_cache_server_dcerl.erl
@@ -79,6 +79,7 @@ start(Workers, Options) ->
                             |lists:delete({?PROP_DISC_CACHE_JOURNAL_DIR, JournalDir}, Options2)],
                 {JournalDir1, Options3}
         end,
+    ?debugVal(Options4),
 
     ok = leo_misc:set_env(leo_cache, ?PROP_OPTIONS, Options4),
     Params = [DataDir2,
@@ -340,7 +341,9 @@ start_1(Id, [DataDir, JournalDir, CacheCapacity, ThresholdLen] = Params) ->
     ProcId = ?gen_proc_id(Id, ?ID_PREFIX),
     DataDir1 = lists:append([DataDir, integer_to_list(Id), ?STR_SLASH]),
     JournalDir1 = lists:append([JournalDir, integer_to_list(Id), ?STR_SLASH]),
-    {ok, Pid} = leo_dcerl_server:start_link(
+    %% {ok, Pid} = leo_dcerl_server:start_link(
+    %%               ProcId, DataDir1, JournalDir1, CacheCapacity, ThresholdLen),
+    {ok, Pid} = leo_dcerl_sup:start_child(
                   ProcId, DataDir1, JournalDir1, CacheCapacity, ThresholdLen),
     true = ets:insert(?ETS_DISC_CACHE_HANDLERS, {Id, Pid}),
     start_1(Id - 1, Params).

--- a/src/leo_cache_server_dcerl.erl
+++ b/src/leo_cache_server_dcerl.erl
@@ -38,6 +38,7 @@
 -export([start/2, stop/0,
          get_filepath/2, get_ref/2, get/2, get/3,
          put/3, put/4, put_begin_tran/2, put_end_tran/5,
+         get_size/2, get_cachepath/2,
          delete/2, stats/0]).
 
 -define(ID_PREFIX, "leo_dcerl_").
@@ -296,6 +297,49 @@ put_end_tran(Id, Ref, Key, Meta, IsCommit) ->
             end
     end.
 
+-spec(get_size(Id, Key) ->
+            {ok, integer()} | {error, any()} when Id::integer(),
+                                                  Key::binary()|any()).
+get_size(Id, Key) ->
+    case ?get_handler(?ETS_DISC_CACHE_HANDLERS, Id) of
+        undefined ->
+            ?warn(?MODULE_STRING, "get_size/2", ?ERROR_MAYBE_CRASH_SERVER),
+            ok = restart(Id),
+            {error, ?ERROR_DISC_CACHE_INACTIVE};
+        Pid ->
+            case gen_server:call(Pid, {get_size, Key}) of
+                {ok, Size} ->
+                    {ok, Size};
+                not_found ->
+                    not_found;
+                {error, Cause} ->
+                    ?warn(?MODULE_STRING, "get_size/2", Cause),
+                    ok = restart(Id, Pid),
+                    {error, Cause}
+            end
+    end.
+
+-spec(get_cachepath(Id, Key) ->
+            {ok, string()} | {error, any()} when Id::integer(),
+                                                 Key::binary()|any()).
+get_cachepath(Id, Key) ->
+    case ?get_handler(?ETS_DISC_CACHE_HANDLERS, Id) of
+        undefined ->
+            ?warn(?MODULE_STRING, "get_cachepath/2", ?ERROR_MAYBE_CRASH_SERVER),
+            ok = restart(Id),
+            {error, ?ERROR_DISC_CACHE_INACTIVE};
+        Pid ->
+            case gen_server:call(Pid, {get_cachepath, Key}) of
+                {ok, Path} ->
+                    {ok, Path};
+                not_found ->
+                    not_found;
+                {error, Cause} ->
+                    ?warn(?MODULE_STRING, "get_cachepath/2", Cause),
+                    ok = restart(Id, Pid),
+                    {error, Cause}
+            end
+    end.
 
 %% @doc Remove an object from cache-server
 -spec(delete(Id, Key) ->

--- a/src/leo_cache_server_mcerl.erl
+++ b/src/leo_cache_server_mcerl.erl
@@ -227,7 +227,7 @@ start_1(0, _) ->
     ok;
 start_1(Id, CacheCapacity) ->
     ProcId = ?gen_proc_id(Id, ?ID_PREFIX),
-    {ok, Pid} = leo_mcerl_server:start_link(ProcId, CacheCapacity),
+    {ok, Pid} = leo_mcerl_sup:start_child(ProcId, CacheCapacity),
     true = ets:insert(?ETS_RAM_CACHE_HANDLERS, {Id, Pid}),
     start_1(Id - 1, CacheCapacity).
 

--- a/src/leo_cache_sup.erl
+++ b/src/leo_cache_sup.erl
@@ -29,6 +29,8 @@
 
 -behaviour(supervisor).
 
+-include("leo_cache.hrl").
+
 %% API
 -export([start_link/0]).
 
@@ -36,6 +38,9 @@
 -export([init/1]).
 
 %% Helper macro for declaring children of supervisor
+-define(MAX_RESTART,              5).
+-define(MAX_TIME,                60).
+-define(SHUTDOWN_WAITING_TIME, 2000).
 -define(CHILD(I, Type), {I, {I, start_link, []}, permanent, 5000, Type, [I]}).
 
 %% ===================================================================
@@ -48,7 +53,68 @@ start_link() ->
 %% ===================================================================
 %% Supervisor callbacks
 %% ===================================================================
-
 init([]) ->
-    {ok, { {one_for_one, 5, 10}, []} }.
+    %% Create tables
+    ok = leo_misc:init_env(),
+    case ets:info(?ETS_RAM_CACHE_HANDLERS) of
+        undefined ->
+            case ets:new(?ETS_RAM_CACHE_HANDLERS,
+                         [named_table, set, public, {read_concurrency, true}]) of
+                ?ETS_RAM_CACHE_HANDLERS ->
+                    ok;
+                _ ->
+                    erlang:error({error, could_not_create_ets_table})
+            end;
+        _ ->
+            ok
+    end,
+    case ets:info(?ETS_DISC_CACHE_HANDLERS) of
+        undefined ->
+            case ets:new(?ETS_DISC_CACHE_HANDLERS,
+                         [named_table, set, public, {read_concurrency, true}]) of
+                ?ETS_DISC_CACHE_HANDLERS ->
+                    ok;
+                _ ->
+                    erlang:error({error, could_not_create_ets_table})
+            end;
+        _ ->
+            ok
+    end,
+    case ets:info(?ETS_CACHE_SERVER_INFO) of
+        undefined ->
+            case ets:new(?ETS_CACHE_SERVER_INFO,
+                         [named_table, set, public, {read_concurrency, true}])of
+                ?ETS_CACHE_SERVER_INFO ->
+                    ok;
+                _ ->
+                    erlang:error({error, could_not_create_ets_table})
+            end;
+        _ ->
+            ok
+    end,
+
+    %% Set supervised childrens
+    Children = [
+                {leo_mcerl_sup,
+                 {leo_mcerl_sup, start_link, []},
+                 permanent,
+                 ?SHUTDOWN_WAITING_TIME,
+                 supervisor,
+                 [leo_mcerl_sup]},
+
+                {leo_dcerl_sup,
+                 {leo_dcerl_sup, start_link, []},
+                 permanent,
+                 ?SHUTDOWN_WAITING_TIME,
+                 supervisor,
+                 [leo_dcerl_sup]},
+
+                {leo_cache_tran,
+                 {leo_cache_tran, start_link, []},
+                 permanent,
+                 ?SHUTDOWN_WAITING_TIME,
+                 supervisor,
+                 [leo_cache_tran]}
+               ],
+    {ok, {_SupFlags = {one_for_one, ?MAX_RESTART, ?MAX_TIME}, Children}}.
 

--- a/src/leo_cache_tran.erl
+++ b/src/leo_cache_tran.erl
@@ -1,0 +1,191 @@
+%%======================================================================
+%%
+%% LeoProject
+%%
+%% Copyright (c) 2013-2014 Rakuten, Inc.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%%======================================================================
+-module(leo_cache_tran).
+-author('Yosuke Hara').
+
+-behaviour(gen_server).
+
+-include_lib("eunit/include/eunit.hrl").
+
+
+%% API
+-export([start_link/0,
+         stop/0]).
+
+-export([tran/3,
+         has_tran/2,
+         done_tran/2]).
+
+-export([init/1,
+         handle_call/3,
+         handle_cast/2,
+         handle_info/2,
+         terminate/2,
+         code_change/3]).
+
+-define(TIMEOUT, timer:seconds(5)).
+-define(WAITTIME, timer:seconds(10)).
+-define(PROCESSDB, leo_cache_tran_proc_db).
+-define(REPLYDB, leo_cache_tran_reply_db).
+
+
+%%--------------------------------------------------------------------
+%% API
+%%--------------------------------------------------------------------
+%% Function: start_link() -> {ok,Pid} | ignore | {error,Error}
+%% Description: Starts the server
+start_link() ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+stop() ->
+    gen_server:call(?MODULE, stop).
+
+%% @doc
+-spec(tran(pid(), atom(), binary()) ->
+             ok).
+tran(Pid, Tbl, Key) ->
+    gen_server:call(?MODULE, {tran, Pid, Tbl, Key}, ?TIMEOUT).
+
+
+%% @doc
+-spec(has_tran(atom(), binary()) ->
+             {ok, any()} | {error, any()}).
+has_tran(Tbl, Key) ->
+    case catch gen_server:call(?MODULE, {has_tran, Tbl, Key}, ?WAITTIME) of
+        {'EXIT', {timeout, _}} ->
+%%            gen_server:call(?MODULE, {unregister, Tbl, Key}, ?TIMEOUT),
+            {error, timeout};
+        {'EXIT', Reason} ->
+%%            gen_server:call(?MODULE, {unregister, Tbl, Key}, ?TIMEOUT),
+            {error, Reason};
+        Ret ->
+            Ret
+    end.
+
+%% @doc
+-spec(done_tran(atom(), binary())->
+            ok).
+done_tran(Tbl, Key) ->
+    gen_server:call(?MODULE, {done_tran, Tbl, Key}, ?TIMEOUT).
+
+
+%%--------------------------------------------------------------------
+%% GEN_SERVER CALLBACKS
+%%--------------------------------------------------------------------
+%% Function: init(Args) -> {ok, State}          |
+%%                         {ok, State, Timeout} |
+%%                         ignore               |
+%%                         {stop, Reason}
+%% Description: Initiates the server
+init([]) ->
+    ets:new(?PROCESSDB, [named_table, set, private]),
+    ets:new(?REPLYDB, [named_table, set, private]),
+    {ok, unused, ?TIMEOUT}.
+
+handle_call(stop, _From, State) ->
+    {stop, shutdown, ok, State};
+
+%%handle_call({unregister, Tbl, Key}, From, State) ->
+%%    {Pid, _Ref} = From,
+%%    case ets:lookup(?REPLYDB, {Tbl, Key}) of
+%%        [{{Tbl, Key}, ReplyList}] ->
+%%            ?debugVal(ReplyList),
+%%            ReplyList2 = lists:filter(fun({Pid2, _Ref2}) ->
+%%                                              Pid2 =/= Pid
+%%                                      end, ReplyList),
+%%            ?debugVal(ReplyList2),
+%%            ets:insert(?REPLYDB, {{Tbl, Key}, ReplyList2});
+%%        _ ->
+%%            void
+%%    end,
+%%    {reply, ok, State, ?TIMEOUT};
+
+handle_call({tran, Pid, Tbl, Key}, _From, State) ->
+    MonitorRef = erlang:monitor(process, Pid),
+    ets:insert(?PROCESSDB, {MonitorRef, {Tbl, Key}}), 
+    ets:insert_new(?REPLYDB, {{Tbl, Key}, []}),
+    {reply, ok, State, ?TIMEOUT}; 
+
+handle_call({has_tran, Tbl, Key}, From, State) ->
+    case ets:lookup(?REPLYDB, {Tbl, Key}) of
+        [{{Tbl, Key}, ReplyList}] ->
+            ets:insert(?REPLYDB, {{Tbl, Key}, [From | ReplyList]}),
+            {noreply, State, ?TIMEOUT};
+        _ ->
+            {reply, {ok, not_found}, State, ?TIMEOUT}
+    end;
+
+handle_call({done_tran, Tbl, Key}, _From, State) ->
+    reply_all(Tbl, Key),
+    {reply, ok, State, ?TIMEOUT}.
+
+handle_cast(_Msg, State) ->
+    {noreply, State, ?TIMEOUT}.
+
+
+%% Function: handle_info(Info, State) -> {noreply, State}          |
+%%                                       {noreply, State, Timeout} |
+%%                                       {stop, Reason, State}
+%% Description: Handling all non call/cast messages
+%% handle_info({_Label, {_From, MRef}, get_modules}, State) ->
+%%     {noreply, State};
+handle_info({'DOWN', MonitorRef, _Type, _Pid,_Info}, State) ->
+    case ets:lookup(?PROCESSDB, MonitorRef) of
+        [{MonitorRef, {Tbl, Key}}] ->
+            reply_all(Tbl, Key);
+        _ ->
+            void
+    end,
+    ets:delete(?PROCESSDB, MonitorRef),
+    erlang:demonitor(MonitorRef),
+    {noreply, State, ?TIMEOUT};
+handle_info(_Info, State) ->
+    {noreply, State, ?TIMEOUT}.
+
+
+%% Function: terminate(Reason, State) -> void()
+%% Description: This function is called by a gen_server when it is about to
+%% terminate. It should be the opposite of Module:init/1 and do any necessary
+%% cleaning up. When it returns, the gen_server terminates with Reason.
+%% The return value is ignored.
+terminate(_Reason,_State) ->
+    ok.
+
+
+%% Func: code_change(OldVsn, State, Extra) -> {ok, NewState}
+%% Description: Convert process state when code is changed
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+%%--------------------------------------------------------------------
+%% INNER FUNCTIONS
+%%--------------------------------------------------------------------
+reply_all(Tbl, Key) ->
+    case ets:lookup(?REPLYDB, {Tbl, Key}) of 
+        ReplyList when is_list(ReplyList) ->
+            lists:foreach(fun(Target) ->
+                                  gen_server:reply(Target, {error, terminated})
+                          end, ReplyList);
+        _ ->
+            void
+    end,
+    ets:delete(?REPLYDB, {Tbl, Key}).

--- a/src/leo_cache_tran.erl
+++ b/src/leo_cache_tran.erl
@@ -84,7 +84,8 @@ has_tran(Tbl, Key) ->
 -spec(done_tran(atom(), binary())->
             ok).
 done_tran(Tbl, Key) ->
-    gen_server:call(?MODULE, {done_tran, Tbl, Key}, ?TRAN_TIMEOUT).
+    gen_server:cast(?MODULE, {done_tran, Tbl, Key}).
+%    gen_server:call(?MODULE, {done_tran, Tbl, Key}, ?TRAN_TIMEOUT).
 
 
 %%--------------------------------------------------------------------
@@ -137,8 +138,11 @@ handle_call({done_tran, Tbl, Key}, _From, State) ->
     reply_all(Tbl, Key),
     {reply, ok, State, ?TRAN_TIMEOUT}.
 
+handle_cast({done_tran, Tbl, Key}, State) ->
+    reply_all(Tbl, Key),
+    {noreply, State};
 handle_cast(_Msg, State) ->
-    {noreply, State, ?TRAN_TIMEOUT}.
+    {noreply, State}.
 
 
 %% Function: handle_info(Info, State) -> {noreply, State}          |

--- a/test/leo_cache_api_tests.erl
+++ b/test/leo_cache_api_tests.erl
@@ -42,10 +42,12 @@ cache_test_() ->
                           ]]}.
 
 setup() ->
+    ok = application:start(leo_cache),
     os:cmd("rm -rf ./cache"),
     ok.
 
 teardown(_) ->
+    ok = application:stop(leo_cache),
     ok.
 
 %% for RAM Cache
@@ -60,6 +62,7 @@ suite_1_(_) ->
                 {?PROP_DISC_CACHE_DATA_DIR,    ?DEF_PROP_DISC_CACHE_DATA_DIR},
                 {?PROP_DISC_CACHE_JOURNAL_DIR, ?DEF_PROP_DISC_CACHE_JOURNAL_DIR}
                ],
+    ?debugVal(Options),
     leo_cache_api:start(Options),
 
     Key1 = <<"photo/image/hawaii-0.png">>,

--- a/test/leo_cache_api_tests.erl
+++ b/test/leo_cache_api_tests.erl
@@ -130,7 +130,7 @@ suite_2_(_) ->
     ?assertEqual(0, CS2#stats.records),
 
     %% Test - PUT#2
-    {ok, Ref} = leo_cache_api:put_begin_tran(BinKey),
+    {ok, write, Ref} = leo_cache_api:put_begin_tran(BinKey),
     Chunk = data_block(Src, 1001),
     ok = leo_cache_api:put(Ref, BinKey, Chunk),
     ok = leo_cache_api:put(Ref, BinKey, Chunk),

--- a/test/leo_cache_tran_tests.erl
+++ b/test/leo_cache_tran_tests.erl
@@ -37,22 +37,22 @@ lock_test() ->
     leo_cache_tran:start_link(),
 
     ?debugMsg(" * Lock   {object, 1}"),
-    leo_cache_tran:tran(self(), object, 1),
+    leo_cache_tran:begin_tran(self(), object, 1),
 
     ?debugMsg(" * Check  {object, 1} (timeout)"),
-    {error, timeout} = leo_cache_tran:has_tran(object, 1),
+    {error, timeout} = leo_cache_tran:wait_tran(object, 1),
 
     ?debugMsg(" * Check  {object, 2} (not found)"),
-    {ok, not_found} = leo_cache_tran:has_tran(object, 2),
+    {ok, not_found} = leo_cache_tran:wait_tran(object, 2),
 
     ?debugMsg(" * Unlock {object, 1} after short delay"),
-    timer:apply_after(200, leo_cache_tran, done_tran, [object, 1]),
+    timer:apply_after(200, leo_cache_tran, end_tran, [object, 1]),
 
     ?debugMsg(" * Check  {object, 1} (done)"),
-    {ok, done} = leo_cache_tran:has_tran(object, 1),
+    {ok, done} = leo_cache_tran:wait_tran(object, 1),
 
     ?debugMsg(" * Check  {object, 1} (not found)"),
-    {ok, not_found} = leo_cache_tran:has_tran(object, 1),
+    {ok, not_found} = leo_cache_tran:wait_tran(object, 1),
 
     leo_cache_tran:stop(),
     ok.

--- a/test/leo_cache_tran_tests.erl
+++ b/test/leo_cache_tran_tests.erl
@@ -1,0 +1,64 @@
+%%====================================================================
+%%
+%% Leo Cache
+%%
+%% Copyright (c) 2012-2014 Rakuten, Inc.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+%% Leo Cache - TEST
+%% @doc
+%% @end
+%%====================================================================
+-module(leo_cache_tran_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+
+%%--------------------------------------------------------------------
+%% TEST FUNCTIONS
+%%--------------------------------------------------------------------
+-ifdef(EUNIT).
+lock_test() ->
+    ?debugMsg(" ===== Basic Test ====="),
+    leo_cache_tran:start_link(),
+
+    ?debugMsg(" * Lock   {object, 1}"),
+    leo_cache_tran:tran(self(), object, 1),
+
+    ?debugMsg(" * Check  {object, 1} (timeout)"),
+    {error, timeout} = leo_cache_tran:has_tran(object, 1),
+
+    ?debugMsg(" * Check  {object, 2} (not found)"),
+    {ok, not_found} = leo_cache_tran:has_tran(object, 2),
+
+    ?debugMsg(" * Unlock {object, 1} after short delay"),
+    timer:apply_after(200, leo_cache_tran, done_tran, [object, 1]),
+
+    ?debugMsg(" * Check  {object, 1} (done)"),
+    {ok, done} = leo_cache_tran:has_tran(object, 1),
+
+    ?debugMsg(" * Check  {object, 1} (not found)"),
+    {ok, not_found} = leo_cache_tran:has_tran(object, 1),
+
+    leo_cache_tran:stop(),
+    ok.
+
+%%--------------------------------------------------------------------
+%% INTERNAL FUNCTIONS
+%%--------------------------------------------------------------------
+
+-endif.


### PR DESCRIPTION
## Attempt to fix issue leo-project/leofs#325
## Brief Description

Added module `leo_cache_tran`. 
Process can explicitly declare it is going to fill a cache entry by calling `leo_cache_tran:tran/3`
Other processes attempting to access the cache would call `leo_cache_tran:has_ran/2` to check if there is a pending fetching, if so, wait until it is completed (or timeout `WAITTIME`)
## Usage Code

windkit/leo_gateway@6672e7a6
Currently "lock"s are released upon process shutdown, it could be possible to reduce the "lock" time by calling `leo_cache_tran:done_tran/2` once the cache is filled instead of after the whole serving process
## Testing Status

Small scale testing is done on VM, show some improvement (10%) in latency
